### PR TITLE
style: polish base components

### DIFF
--- a/components/FileUploader.module.css
+++ b/components/FileUploader.module.css
@@ -1,6 +1,13 @@
-.uploader {
-  padding: 8px;
-  border: 2px dashed #ccc;
-  border-radius: 4px;
-  background: white;
+.root {
+  padding: 1rem;
+  border: 2px dashed var(--color-border);
+  border-radius: 0.75rem;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.root:focus-within {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(46, 125, 50, 0.3);
 }

--- a/components/FileUploader.tsx
+++ b/components/FileUploader.tsx
@@ -27,7 +27,7 @@ export default function FileUploader({ onUploaded }: Props) {
   }
 
   return (
-    <div className={styles.uploader}>
+    <div className={styles.root}>
       <input type="file" accept="application/pdf" onChange={upload} disabled={uploading} />
     </div>
   );

--- a/components/Input.module.css
+++ b/components/Input.module.css
@@ -1,6 +1,16 @@
-.input {
-  padding: 8px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
+.root {
+  padding: 0.5rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0.75rem;
   font-size: 14px;
+  background: var(--color-surface);
+  color: var(--color-text);
+  box-shadow: var(--shadow-sm);
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.root:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(46, 125, 50, 0.3);
 }

--- a/components/Input.tsx
+++ b/components/Input.tsx
@@ -3,5 +3,5 @@ import { InputHTMLAttributes } from 'react';
 import styles from './Input.module.css';
 
 export default function Input(props: InputHTMLAttributes<HTMLInputElement>) {
-  return <input {...props} className={styles.input} />;
+  return <input {...props} className={styles.root} />;
 }

--- a/components/Modal.module.css
+++ b/components/Modal.module.css
@@ -1,14 +1,24 @@
 .backdrop {
   position: fixed;
-  top: 0; left: 0; right: 0; bottom: 0;
-  background: rgba(0,0,0,0.5);
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 1rem;
 }
-.modal {
-  background: #fff;
-  padding: 16px;
-  border-radius: 4px;
+
+.card {
+  background: var(--color-surface);
+  color: var(--color-text);
+  padding: 1.5rem;
+  border-radius: 0.75rem;
+  box-shadow: var(--shadow-md);
   max-width: 90%;
+}
+
+@media (prefers-color-scheme: dark) {
+  .backdrop {
+    background: rgba(0, 0, 0, 0.7);
+  }
 }

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -12,7 +12,7 @@ export default function Modal({ open, onClose, children }: Props) {
   if (!open) return null;
   return (
     <div className={styles.backdrop} onClick={onClose}>
-      <div className={styles.modal} onClick={e => e.stopPropagation()}>
+      <div className={styles.card} onClick={e => e.stopPropagation()}>
         {children}
       </div>
     </div>

--- a/components/Stepper.module.css
+++ b/components/Stepper.module.css
@@ -1,15 +1,37 @@
-.stepper {
+.root {
   display: flex;
   list-style: none;
   padding: 0;
+  margin: 0;
+  background: var(--color-surface);
+  border-radius: 0.75rem;
+  box-shadow: var(--shadow-sm);
 }
-.stepper li {
+
+.step {
   flex: 1;
-  text-align: center;
-  padding: 8px;
-  border-bottom: 2px solid #ccc;
 }
-.stepper li.active {
+
+.btn {
+  width: 100%;
+  padding: 0.5rem;
+  background: none;
+  border: none;
+  border-bottom: 2px solid var(--color-border);
+  color: var(--color-text);
+  cursor: pointer;
+  font: inherit;
+  border-radius: 0.75rem 0.75rem 0 0;
+  transition: border-color 0.2s;
+}
+
+.btn:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(46, 125, 50, 0.3);
+}
+
+.active {
   border-color: var(--color-primary);
   font-weight: bold;
 }

--- a/components/Stepper.tsx
+++ b/components/Stepper.tsx
@@ -1,15 +1,39 @@
+"use client";
+
+import { KeyboardEvent } from 'react';
 import styles from './Stepper.module.css';
 
 interface Props {
   steps: string[];
   active: number;
+  onStepChange: (index: number) => void;
 }
 
-export default function Stepper({ steps, active }: Props) {
+export default function Stepper({ steps, active, onStepChange }: Props) {
+  function handleKey(index: number, e: KeyboardEvent<HTMLButtonElement>) {
+    if (e.key === 'ArrowRight') {
+      onStepChange(Math.min(steps.length - 1, index + 1));
+    } else if (e.key === 'ArrowLeft') {
+      onStepChange(Math.max(0, index - 1));
+    }
+  }
+
   return (
-    <ol className={styles.stepper}>
+    <ol className={styles.root} role="tablist">
       {steps.map((s, i) => (
-        <li key={s} className={i === active ? styles.active : ''}>{s}</li>
+        <li key={s} className={styles.step}>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={i === active}
+            tabIndex={i === active ? 0 : -1}
+            className={i === active ? `${styles.btn} ${styles.active}` : styles.btn}
+            onClick={() => onStepChange(i)}
+            onKeyDown={(e) => handleKey(i, e)}
+          >
+            {s}
+          </button>
+        </li>
       ))}
     </ol>
   );

--- a/components/Table.module.css
+++ b/components/Table.module.css
@@ -1,13 +1,26 @@
-.table {
+.root {
   width: 100%;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
+  background: var(--color-surface);
+  border-radius: 0.75rem;
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
 }
-.table th,
-.table td {
-  padding: 8px;
-  border: 1px solid #ddd;
+
+.root th,
+.root td {
+  padding: 0.5rem;
+  border-bottom: 1px solid var(--color-border);
 }
-.table th {
-  background: #eee;
+
+.root th {
+  background: #f3f4f6;
   text-align: left;
+}
+
+@media (prefers-color-scheme: dark) {
+  .root th {
+    background: #374151;
+  }
 }

--- a/components/Table.tsx
+++ b/components/Table.tsx
@@ -2,5 +2,5 @@ import { ReactNode } from 'react';
 import styles from './Table.module.css';
 
 export default function Table({ children }: { children: ReactNode }) {
-  return <table className={styles.table}>{children}</table>;
+  return <table className={styles.root}>{children}</table>;
 }

--- a/components/Toast.module.css
+++ b/components/Toast.module.css
@@ -1,9 +1,10 @@
-.toast {
+.root {
   position: fixed;
-  bottom: 16px;
-  right: 16px;
-  background: #333;
-  color: #fff;
-  padding: 8px 12px;
-  border-radius: 4px;
+  bottom: 1rem;
+  right: 1rem;
+  background: var(--color-surface);
+  color: var(--color-text);
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  box-shadow: var(--shadow-md);
 }

--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -11,5 +11,5 @@ export default function Toast({ message, duration = 3000 }: Props) {
     return () => clearTimeout(id);
   }, [duration]);
   if (!visible) return null;
-  return <div className={styles.toast}>{message}</div>;
+  return <div className={styles.root}>{message}</div>;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3,8 +3,8 @@ html, body {
   margin: 0;
   padding: 0;
   font-family: sans-serif;
-  background: #f5f5f5;
-  color: #222;
+  background: var(--color-bg);
+  color: var(--color-text);
 }
 a { color: inherit; text-decoration: none; }
 * { box-sizing: border-box; }

--- a/styles/variables.css
+++ b/styles/variables.css
@@ -2,5 +2,18 @@
   --color-primary: #2e7d32;
   --color-secondary: #1565c0;
   --color-bg: #f5f5f5;
+  --color-surface: #fff;
   --color-text: #222;
+  --color-border: #d1d5db;
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg: #1f2937;
+    --color-surface: #111827;
+    --color-text: #f9fafb;
+    --color-border: #4b5563;
+  }
 }


### PR DESCRIPTION
## Summary
- refactor base components to match polished card style
- add dark mode color variables and global use
- implement keyboard-accessible stepper navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46e45bf94832f9023fe1d3005e10d