### PR TITLE
Enforce strict row security and audit logging

### DIFF
--- a/app/(dashboard)/reports/[id]/page.tsx
+++ b/app/(dashboard)/reports/[id]/page.tsx
@@ -2,10 +2,14 @@ import { createServerClient } from '../../../../lib/supabase/server';
 import { aiProvider } from '../../../../lib/ai';
 import Table from '../../../../components/Table';
 import { formatMoney } from '../../../../lib/utils';
+import { logAccess } from '../../../../lib/supabase/access-log';
 
 export default async function ReportDetail({ params }: { params: { id: string } }) {
   const supabase = createServerClient();
   const { data: report } = await supabase.from('credit_reports').select('*').eq('id', params.id).single();
+  if (report) {
+    await logAccess(supabase, report.user_id, 'credit_reports', { id: params.id });
+  }
   const { data: tradelines } = await supabase.from('tradelines').select('*').eq('report_id', params.id);
 
   async function findCandidates() {

--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -1,10 +1,14 @@
 import { createServerClient } from '../../../lib/supabase/server';
 import { profileSchema } from '../../../lib/validation';
 import { revalidatePath } from 'next/cache';
+import { logAccess } from '../../../lib/supabase/access-log';
 
 export default async function SettingsPage() {
   const supabase = createServerClient();
   const { data: profile } = await supabase.from('profiles').select('*').single();
+  if (profile) {
+    await logAccess(supabase, profile.id, 'profiles');
+  }
 
   async function updateProfile(formData: FormData) {
     'use server';

--- a/lib/supabase/access-log.ts
+++ b/lib/supabase/access-log.ts
@@ -1,0 +1,21 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { Database } from '../../types/database.types';
+
+export async function logAccess(
+  client: SupabaseClient<Database>,
+  userId: string,
+  resource: string,
+  details?: Record<string, any>
+) {
+  const {
+    data: { user },
+  } = await client.auth.getUser();
+  await client.from('audit_access').insert({
+    id: crypto.randomUUID(),
+    user_id: userId,
+    actor: user?.id ?? null,
+    resource,
+    action: 'read',
+    details,
+  });
+}

--- a/lib/supabase/storage.ts
+++ b/lib/supabase/storage.ts
@@ -1,7 +1,17 @@
 import { createServerClient } from './server';
 
-export async function getSignedUrl(bucket: string, path: string, expires = 60) {
+export async function getSignedUrl(
+  bucket: string,
+  userId: string,
+  path: string,
+  expires = 60
+) {
+  if (!path.startsWith(`users/${userId}/`)) {
+    throw new Error('Invalid path');
+  }
   const supabase = createServerClient();
-  const { data } = await supabase.storage.from(bucket).createSignedUrl(path, expires);
+  const { data } = await supabase.storage
+    .from(bucket)
+    .createSignedUrl(path, expires);
   return data?.signedUrl;
 }

--- a/sql/migration.sql
+++ b/sql/migration.sql
@@ -108,11 +108,24 @@ create policy "Profiles are insertable by owner" on profiles for insert with che
 create policy "Profiles are updatable by owner" on profiles for update using ( id = auth.uid() );
 
 create policy "Reports by owner" on credit_reports for all using ( user_id = auth.uid() ) with check ( user_id = auth.uid() );
-create policy "Tradelines by owner" on tradelines for all using ( exists (select 1 from credit_reports cr where cr.id = report_id and cr.user_id = auth.uid()) );
+create policy "Tradelines by owner" on tradelines for all
+  using (
+    exists (
+      select 1 from credit_reports cr
+      where cr.id = report_id and cr.user_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1 from credit_reports cr
+      where cr.id = report_id and cr.user_id = auth.uid()
+    )
+  );
 create policy "Candidates by owner" on dispute_candidates for all using ( user_id = auth.uid() ) with check ( user_id = auth.uid() );
 create policy "Disputes by owner" on disputes for all using ( user_id = auth.uid() ) with check ( user_id = auth.uid() );
 create policy "Notifications by owner" on notifications for all using ( user_id = auth.uid() ) with check ( user_id = auth.uid() );
 create policy "Audit read by owner" on audit_access for select using ( user_id = auth.uid() );
+create policy "Audit insert by owner" on audit_access for insert with check ( user_id = auth.uid() );
 
 -- Trigger to insert profile on signup
 create or replace function public.handle_new_user()

--- a/tests/rls.spec.ts
+++ b/tests/rls.spec.ts
@@ -1,0 +1,37 @@
+import { createClient } from '@supabase/supabase-js';
+import { test, expect } from 'vitest';
+
+const url = process.env.SUPABASE_URL as string;
+const anon = process.env.SUPABASE_ANON_KEY as string;
+const service = process.env.SUPABASE_SERVICE_ROLE_KEY as string;
+
+// These tests require a running Supabase instance with the database schema applied.
+
+async function setupUsers() {
+  const admin = createClient(url, service);
+  const { data: u1 } = await admin.auth.admin.createUser({ email: 'user1@example.com', password: 'password' });
+  const { data: u2 } = await admin.auth.admin.createUser({ email: 'user2@example.com', password: 'password' });
+  await admin.from('profiles').insert([
+    { id: u1.user!.id, email: 'user1@example.com' },
+    { id: u2.user!.id, email: 'user2@example.com' },
+  ]);
+  return { u1: u1.user!, u2: u2.user! };
+}
+
+test('users cannot read other profiles', async () => {
+  const { u1, u2 } = await setupUsers();
+  const c1 = createClient(url, anon);
+  await c1.auth.signInWithPassword({ email: 'user1@example.com', password: 'password' });
+  const { data } = await c1.from('profiles').select('*').eq('id', u2.id);
+  expect(data).toHaveLength(0);
+});
+
+test('users cannot insert reports for others', async () => {
+  const { u1, u2 } = await setupUsers();
+  const c1 = createClient(url, anon);
+  await c1.auth.signInWithPassword({ email: 'user1@example.com', password: 'password' });
+  const { error } = await c1
+    .from('credit_reports')
+    .insert({ id: crypto.randomUUID(), user_id: u2.id, bureau: 'equifax', src_path: `users/${u2.id}/report.pdf` });
+  expect(error).toBeTruthy();
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['lib/**/*.test.ts'],
+    include: ['lib/**/*.test.ts', 'tests/rls.spec.ts'],
   },
 });


### PR DESCRIPTION
## Summary
- Add explicit RLS policies for tradelines and audit_access
- Log PII reads to audit_access and validate signed storage paths
- Add tests for cross-user access denials

## Testing
- `npm test` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68b4937882c8832f9de18a071cf164ae