### PR TITLE
Add AI provider interface with prompt guards

### DIFF
--- a/lib/ai/guards.test.ts
+++ b/lib/ai/guards.test.ts
@@ -1,11 +1,29 @@
 import { describe, expect, it, afterEach } from 'vitest';
-import { redactPII, requireApiKey } from './guards';
+import { redactPII, requireApiKey, maskAccountNumbers } from './guards';
 
 describe('redactPII', () => {
   it('removes PII fields', () => {
     const input = { name: 'Jane', email: 'jane@example.com', score: 720 };
     const result = redactPII(input);
     expect(result).toEqual({ score: 720 });
+  });
+
+  it('strips SSN and masks account numbers', () => {
+    const input = {
+      ssn: '123-45-6789',
+      accountNumber: '123456789',
+      note: 'acct 987654321',
+    };
+    const result = redactPII(input);
+    expect(result.ssn).toBeUndefined();
+    expect(result.accountNumber).toBe('*****6789');
+    expect(result.note).toBe('acct *****4321');
+    expect(JSON.stringify(result)).not.toMatch(/\d{5,}/);
+  });
+
+  it('masks embedded numbers in strings', () => {
+    const masked = maskAccountNumbers('SSN 123-45-6789 and acct 123456789');
+    expect(masked).toBe('SSN ***-**-6789 and acct *****6789');
   });
 });
 

--- a/lib/ai/guards.ts
+++ b/lib/ai/guards.ts
@@ -16,11 +16,25 @@ export const PII_FIELDS = [
   'dateOfBirth',
 ];
 
+export function maskAccountNumbers(str: string): string {
+  return str.replace(/(\d[\d- ]{4,}\d)/g, (match) => {
+    const digits = match.replace(/\D/g, '');
+    if (digits.length < 5) return match;
+    const masked = '*'.repeat(digits.length - 4) + digits.slice(-4);
+    let i = 0;
+    return match.replace(/\d/g, () => masked[i++]);
+  });
+}
+
 export function redactPII<T extends Record<string, any>>(data: T): Partial<T> {
   const clean: Record<string, any> = {};
   for (const key in data) {
     if (!PII_FIELDS.includes(key)) {
-      clean[key] = (data as any)[key];
+      let value = (data as any)[key];
+      if (typeof value === 'string') {
+        value = maskAccountNumbers(value);
+      }
+      clean[key] = value;
     }
   }
   return clean;

--- a/lib/ai/index.ts
+++ b/lib/ai/index.ts
@@ -12,12 +12,12 @@ export interface ScoreSimulation {
   notes: string;
 }
 
-export interface AIProvider {
+export interface IAiProvider {
   suggestDisputes(reportId: string): Promise<DisputeSuggestion[]>;
   simulate(score: number, utilizationDelta: number): Promise<ScoreSimulation>;
 }
 
-class MockAI implements AIProvider {
+class MockAiProvider implements IAiProvider {
   async suggestDisputes(reportId: string): Promise<DisputeSuggestion[]> {
     return [
       {
@@ -41,6 +41,7 @@ class MockAI implements AIProvider {
 }
 
 export { OpenAIProvider } from './openai';
+export { MockAiProvider };
 
-export const aiProvider: AIProvider =
-  process.env.OPENAI_API_KEY ? new OpenAIProvider() : new MockAI();
+export const aiProvider: IAiProvider =
+  process.env.OPENAI_API_KEY ? new OpenAIProvider() : new MockAiProvider();


### PR DESCRIPTION
## Summary
- define `IAiProvider` interface with `MockAiProvider` default and `OpenAIProvider` via env flag
- add `maskAccountNumbers` and enhance `redactPII` to guard prompts
- update `OpenAIProvider` to apply masking
- test masking for SSNs and account numbers

## Testing
- `npm test` *(fails: Playwright tests expect environment; missing supabase url)*
- `npx vitest lib/ai/guards.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b4a1839b70832fae3bd9ebacbca335