### PR TITLE
feat: polish UI with cards, toasts, and confirmations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .DS_Store
 coverage
 playwright-report
+tsconfig.tsbuildinfo

--- a/app/(dashboard)/disputes/[id]/page.tsx
+++ b/app/(dashboard)/disputes/[id]/page.tsx
@@ -109,8 +109,12 @@ export default async function DisputeDetail({ params }: { params: { id: string }
     <div>
       <h1>Dispute {params.id}</h1>
       <pre>{JSON.stringify(dispute, null, 2)}</pre>
-      <FormWithToast action={genLetter}><button type="submit">Generate Letter</button></FormWithToast>
-      <FormWithToast action={markMailed}><button type="submit">Mark as mailed</button></FormWithToast>
+      <FormWithToast action={genLetter}>
+        <button type="submit">Generate Letter</button>
+      </FormWithToast>
+      <FormWithToast action={markMailed} confirmMessage="Mark as mailed?">
+        <button type="submit">Mark as mailed</button>
+      </FormWithToast>
       {letterUrl && <a href={letterUrl}>Download Letter</a>}
     </div>
   );

--- a/app/(dashboard)/disputes/loading.tsx
+++ b/app/(dashboard)/disputes/loading.tsx
@@ -1,0 +1,10 @@
+import Skeleton from '../../../components/Skeleton';
+
+export default function Loading() {
+  return (
+    <div>
+      <h1>Disputes</h1>
+      <Skeleton lines={3} />
+    </div>
+  );
+}

--- a/app/(dashboard)/disputes/page.module.css
+++ b/app/(dashboard)/disputes/page.module.css
@@ -1,0 +1,8 @@
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}

--- a/app/(dashboard)/disputes/page.tsx
+++ b/app/(dashboard)/disputes/page.tsx
@@ -1,15 +1,35 @@
 import Link from 'next/link';
 import { createServerClient } from '../../../lib/supabase/server';
+import Card from '../../../components/Card';
+import EmptyState from '../../../components/EmptyState';
+import styles from './page.module.css';
 
 export default async function DisputesPage() {
   const supabase = createServerClient();
-  const { data } = await supabase.from('disputes').select('*').order('created_at', { ascending: false });
+  const { data } = await supabase
+    .from('disputes')
+    .select('*')
+    .order('created_at', { ascending: false });
+
+  if (!data || data.length === 0) {
+    return (
+      <div>
+        <h1>Disputes</h1>
+        <EmptyState message="No disputes yet" />
+      </div>
+    );
+  }
+
   return (
     <div>
       <h1>Disputes</h1>
-      <ul>
-        {data?.map(d => (
-          <li key={d.id}><Link href={`/disputes/${d.id}`}>{d.status}</Link></li>
+      <ul className={styles.list}>
+        {data.map((d) => (
+          <li key={d.id}>
+            <Card>
+              <Link href={`/disputes/${d.id}`}>{d.status}</Link>
+            </Card>
+          </li>
         ))}
       </ul>
     </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,18 @@
 import './globals.css';
 import type { ReactNode } from 'react';
+import { ToastProvider } from '../components/ToastProvider';
+import { ConfirmProvider } from '../components/ConfirmProvider';
 
 export const metadata = { title: 'CreditCraft' };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <ToastProvider>
+          <ConfirmProvider>{children}</ConfirmProvider>
+        </ToastProvider>
+      </body>
     </html>
   );
 }

--- a/components/Card.module.css
+++ b/components/Card.module.css
@@ -1,0 +1,7 @@
+.root {
+  background: var(--color-surface);
+  color: var(--color-text);
+  padding: var(--space-4);
+  border-radius: var(--space-3);
+  box-shadow: var(--shadow-sm);
+}

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,0 +1,6 @@
+import { ReactNode } from 'react';
+import styles from './Card.module.css';
+
+export default function Card({ children }: { children: ReactNode }) {
+  return <div className={styles.root}>{children}</div>;
+}

--- a/components/Confirm.module.css
+++ b/components/Confirm.module.css
@@ -1,0 +1,28 @@
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+}
+
+.actions button {
+  padding: var(--space-2) var(--space-3);
+  border: none;
+  border-radius: var(--space-2);
+  cursor: pointer;
+}
+
+.actions button:first-of-type {
+  background: var(--color-border);
+  color: var(--color-text);
+}
+
+.actions button:last-of-type {
+  background: var(--color-primary);
+  color: white;
+}

--- a/components/ConfirmProvider.tsx
+++ b/components/ConfirmProvider.tsx
@@ -1,0 +1,49 @@
+'use client';
+import { createContext, ReactNode, useContext, useState } from 'react';
+import Modal from './Modal';
+import styles from './Confirm.module.css';
+
+interface ConfirmState {
+  message: string;
+  resolve: (v: boolean) => void;
+}
+
+const ConfirmContext = createContext<((message: string) => Promise<boolean>) | null>(null);
+
+export function ConfirmProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<ConfirmState | null>(null);
+
+  function confirm(message: string) {
+    return new Promise<boolean>((resolve) => {
+      setState({ message, resolve });
+    });
+  }
+
+  function handleClose(result: boolean) {
+    state?.resolve(result);
+    setState(null);
+  }
+
+  return (
+    <ConfirmContext.Provider value={confirm}>
+      {children}
+      {state && (
+        <Modal open onClose={() => handleClose(false)}>
+          <div className={styles.content}>
+            <p>{state.message}</p>
+            <div className={styles.actions}>
+              <button type="button" onClick={() => handleClose(false)}>Cancel</button>
+              <button type="button" onClick={() => handleClose(true)}>Confirm</button>
+            </div>
+          </div>
+        </Modal>
+      )}
+    </ConfirmContext.Provider>
+  );
+}
+
+export function useConfirm() {
+  const ctx = useContext(ConfirmContext);
+  if (!ctx) throw new Error('useConfirm must be used within ConfirmProvider');
+  return ctx;
+}

--- a/components/EmptyState.module.css
+++ b/components/EmptyState.module.css
@@ -1,0 +1,5 @@
+.root {
+  text-align: center;
+  padding: var(--space-6);
+  color: var(--color-border);
+}

--- a/components/EmptyState.tsx
+++ b/components/EmptyState.tsx
@@ -1,0 +1,5 @@
+import styles from './EmptyState.module.css';
+
+export default function EmptyState({ message }: { message: string }) {
+  return <div className={styles.root}>{message}</div>;
+}

--- a/components/FileUploader.module.css
+++ b/components/FileUploader.module.css
@@ -1,7 +1,7 @@
 .root {
-  padding: 1rem;
+  padding: var(--space-4);
   border: 2px dashed var(--color-border);
-  border-radius: 0.75rem;
+  border-radius: var(--space-3);
   background: var(--color-surface);
   box-shadow: var(--shadow-sm);
   transition: border-color 0.2s, box-shadow 0.2s;

--- a/components/FormWithToast.tsx
+++ b/components/FormWithToast.tsx
@@ -1,8 +1,10 @@
 'use client';
+import { useEffect } from 'react';
 import { useFormState } from 'react-dom/experimental';
-import Toast from './Toast';
 import { AppError, toToast } from '../lib/utils/errors';
 import { ReactNode } from 'react';
+import { useToast } from './ToastProvider';
+import { useConfirm } from './ConfirmProvider';
 
 interface FormState {
   error?: AppError | null;
@@ -11,14 +13,27 @@ interface FormState {
 interface Props {
   action: (formData: FormData) => Promise<FormState>;
   children: ReactNode;
+  confirmMessage?: string;
 }
 
-export default function FormWithToast({ action, children }: Props) {
+export default function FormWithToast({ action, children, confirmMessage }: Props) {
   const [state, formAction] = useFormState(action, { error: null });
-  return (
-    <>
-      {state.error && <Toast message={toToast(state.error)} />}
-      <form action={formAction}>{children}</form>
-    </>
-  );
+  const toast = useToast();
+  const confirm = useConfirm();
+
+  useEffect(() => {
+    if (state.error) {
+      toast(toToast(state.error));
+    }
+  }, [state.error, toast]);
+
+  async function handleAction(formData: FormData) {
+    if (confirmMessage) {
+      const ok = await confirm(confirmMessage);
+      if (!ok) return;
+    }
+    return formAction(formData);
+  }
+
+  return <form action={handleAction}>{children}</form>;
 }

--- a/components/Input.module.css
+++ b/components/Input.module.css
@@ -1,7 +1,7 @@
 .root {
-  padding: 0.5rem;
+  padding: var(--space-2);
   border: 1px solid var(--color-border);
-  border-radius: 0.75rem;
+  border-radius: var(--space-3);
   font-size: 14px;
   background: var(--color-surface);
   color: var(--color-text);
@@ -10,7 +10,6 @@
 }
 
 .root:focus {
-  outline: none;
   border-color: var(--color-primary);
   box-shadow: 0 0 0 3px rgba(46, 125, 50, 0.3);
 }

--- a/components/Modal.module.css
+++ b/components/Modal.module.css
@@ -5,14 +5,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 1rem;
+  padding: var(--space-4);
 }
 
 .card {
   background: var(--color-surface);
   color: var(--color-text);
-  padding: 1.5rem;
-  border-radius: 0.75rem;
+  padding: var(--space-5);
+  border-radius: var(--space-3);
   box-shadow: var(--shadow-md);
   max-width: 90%;
 }

--- a/components/Skeleton.module.css
+++ b/components/Skeleton.module.css
@@ -1,0 +1,18 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.line {
+  height: 1rem;
+  background: var(--color-border);
+  border-radius: var(--space-1);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0% { opacity: 0.6; }
+  50% { opacity: 1; }
+  100% { opacity: 0.6; }
+}

--- a/components/Skeleton.tsx
+++ b/components/Skeleton.tsx
@@ -1,0 +1,13 @@
+import styles from './Skeleton.module.css';
+
+interface Props { lines?: number; }
+
+export default function Skeleton({ lines = 3 }: Props) {
+  return (
+    <div className={styles.root}>
+      {Array.from({ length: lines }).map((_, i) => (
+        <div key={i} className={styles.line} />
+      ))}
+    </div>
+  );
+}

--- a/components/Stepper.module.css
+++ b/components/Stepper.module.css
@@ -4,7 +4,7 @@
   padding: 0;
   margin: 0;
   background: var(--color-surface);
-  border-radius: 0.75rem;
+  border-radius: var(--space-3);
   box-shadow: var(--shadow-sm);
 }
 
@@ -14,19 +14,18 @@
 
 .btn {
   width: 100%;
-  padding: 0.5rem;
+  padding: var(--space-2);
   background: none;
   border: none;
   border-bottom: 2px solid var(--color-border);
   color: var(--color-text);
   cursor: pointer;
   font: inherit;
-  border-radius: 0.75rem 0.75rem 0 0;
+  border-radius: var(--space-3) var(--space-3) 0 0;
   transition: border-color 0.2s;
 }
 
 .btn:focus {
-  outline: none;
   border-color: var(--color-primary);
   box-shadow: 0 0 0 3px rgba(46, 125, 50, 0.3);
 }

--- a/components/Stepper.tsx
+++ b/components/Stepper.tsx
@@ -15,6 +15,10 @@ export default function Stepper({ steps, active, onStepChange }: Props) {
       onStepChange(Math.min(steps.length - 1, index + 1));
     } else if (e.key === 'ArrowLeft') {
       onStepChange(Math.max(0, index - 1));
+    } else if (e.key === 'Home') {
+      onStepChange(0);
+    } else if (e.key === 'End') {
+      onStepChange(steps.length - 1);
     }
   }
 

--- a/components/Table.module.css
+++ b/components/Table.module.css
@@ -3,14 +3,14 @@
   border-collapse: separate;
   border-spacing: 0;
   background: var(--color-surface);
-  border-radius: 0.75rem;
+  border-radius: var(--space-3);
   overflow: hidden;
   box-shadow: var(--shadow-sm);
 }
 
 .root th,
 .root td {
-  padding: 0.5rem;
+  padding: var(--space-2);
   border-bottom: 1px solid var(--color-border);
 }
 

--- a/components/Toast.module.css
+++ b/components/Toast.module.css
@@ -1,10 +1,16 @@
-.root {
+.container {
   position: fixed;
-  bottom: 1rem;
-  right: 1rem;
+  bottom: var(--space-4);
+  right: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.root {
   background: var(--color-surface);
   color: var(--color-text);
-  padding: 0.5rem 0.75rem;
-  border-radius: 0.75rem;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--space-3);
   box-shadow: var(--shadow-md);
 }

--- a/components/ToastProvider.tsx
+++ b/components/ToastProvider.tsx
@@ -1,0 +1,36 @@
+'use client';
+import { createContext, useContext, ReactNode, useState } from 'react';
+import Toast from './Toast';
+import styles from './Toast.module.css';
+
+interface ToastItem { id: number; message: string; duration: number; }
+type ToastFn = (message: string, duration?: number) => void;
+
+const ToastContext = createContext<ToastFn | null>(null);
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+  const push: ToastFn = (message, duration = 3000) => {
+    const id = Date.now();
+    setToasts(t => [...t, { id, message, duration }]);
+    setTimeout(() => setToasts(t => t.filter(toast => toast.id !== id)), duration);
+  };
+
+  return (
+    <ToastContext.Provider value={push}>
+      {children}
+      <div className={styles.container} aria-live="polite">
+        {toasts.map(t => (
+          <Toast key={t.id} message={t.message} duration={t.duration} />
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error('useToast must be used within ToastProvider');
+  return ctx;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -8,3 +8,8 @@ html, body {
 }
 a { color: inherit; text-decoration: none; }
 * { box-sizing: border-box; }
+
+:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}

--- a/styles/variables.css
+++ b/styles/variables.css
@@ -7,6 +7,13 @@
   --color-border: #d1d5db;
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
   --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
+  /* spacing scale */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## Summary
- add design tokens for spacing and focus rings
- introduce card, skeleton, and empty state components
- provide app-wide toast and confirmation modal systems
- improve accessibility with keyboard navigable steppers and loading placeholders

## Testing
- `npm test` *(fails: Failed to load url @react-pdf/renderer)*
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module '@supabase/auth-ui-shared' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a9bc5184832fa3e38974f29f77e9