### PR TITLE
feat: add basic logging and log preview

### DIFF
--- a/app/(dashboard)/settings/logs/page.tsx
+++ b/app/(dashboard)/settings/logs/page.tsx
@@ -1,0 +1,41 @@
+import { createServerClient } from "../../../../lib/supabase/server";
+import { getLogsForUser } from "../../../../lib/logs";
+
+export default async function LogPreviewPage() {
+  const supabase = createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return <div>Not signed in</div>;
+  }
+  const logs = getLogsForUser(user.id).map((l) => ({
+    ...l,
+    requestId: l.requestId.slice(0, 8),
+  }));
+  return (
+    <div>
+      <h1>Recent Logs</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>Request</th>
+            <th>Function</th>
+            <th>Duration (ms)</th>
+            <th>Result</th>
+          </tr>
+        </thead>
+        <tbody>
+          {logs.map((l, i) => (
+            <tr key={i}>
+              <td>{l.requestId}</td>
+              <td>{l.functionName}</td>
+              <td>{l.durationMs}</td>
+              <td>{l.result}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -1,35 +1,45 @@
-import { createServerClient } from '../../../lib/supabase/server';
-import { profileSchema } from '../../../lib/validation';
-import { revalidatePath } from 'next/cache';
-import { logAccess } from '../../../lib/supabase/access-log';
-import FormWithToast from '../../../components/FormWithToast';
-import type { AppError } from '../../../lib/utils/errors';
-import { createMailer } from '../../../lib/mail';
+import { createServerClient } from "../../../lib/supabase/server";
+import { profileSchema } from "../../../lib/validation";
+import { revalidatePath } from "next/cache";
+import { logAccess } from "../../../lib/supabase/access-log";
+import FormWithToast from "../../../components/FormWithToast";
+import type { AppError } from "../../../lib/utils/errors";
+import { createMailer } from "../../../lib/mail";
 
 export default async function SettingsPage() {
   const supabase = createServerClient();
-  const { data: profile } = await supabase.from('profiles').select('*').single();
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("*")
+    .single();
   if (profile) {
-    await logAccess(supabase, profile.id, 'profiles');
+    await logAccess(supabase, profile.id, "profiles");
   }
 
-  async function updateProfile(formData: FormData): Promise<{ error?: AppError }> {
-    'use server';
+  async function updateProfile(
+    formData: FormData,
+  ): Promise<{ error?: AppError }> {
+    "use server";
     const values = Object.fromEntries(formData.entries());
     const parsed = profileSchema.safeParse(values);
     if (!parsed.success) {
-      return { error: { code: 'INVALID_INPUT', message: parsed.error.message } };
+      return {
+        error: { code: "INVALID_INPUT", message: parsed.error.message },
+      };
     }
-    const { error } = await supabase.from('profiles').update(parsed.data).eq('id', profile?.id);
+    const { error } = await supabase
+      .from("profiles")
+      .update(parsed.data)
+      .eq("id", profile?.id);
     if (error) {
-      return { error: { code: 'SERVER_ERROR', message: error.message } };
+      return { error: { code: "SERVER_ERROR", message: error.message } };
     }
-    revalidatePath('/settings');
+    revalidatePath("/settings");
     return {};
   }
 
   async function deleteMyData(): Promise<{ error?: AppError }> {
-    'use server';
+    "use server";
     const run = async (fn: () => Promise<unknown>) => {
       for (let i = 0; i < 3; i++) {
         try {
@@ -45,36 +55,58 @@ export default async function SettingsPage() {
         data: { user },
       } = await supabase.auth.getUser();
       if (!user) {
-        return { error: { code: 'UNAUTHORIZED', message: 'Not signed in' } };
+        return { error: { code: "UNAUTHORIZED", message: "Not signed in" } };
       }
       const mailer = createMailer();
       await run(() =>
         supabase
-          .from('audit_access')
-          .insert({ id: crypto.randomUUID(), user_id: user.id, actor: user.id, resource: 'all', action: 'delete' })
+          .from("audit_access")
+          .insert({
+            id: crypto.randomUUID(),
+            user_id: user.id,
+            actor: user.id,
+            resource: "all",
+            action: "delete",
+          }),
       );
-      await run(() => supabase.storage.from('reports').remove([`users/${user.id}`]));
-      await run(() => supabase.storage.from('letters').remove([`users/${user.id}`]));
-      await run(() => supabase.from('notifications').delete().eq('user_id', user.id));
-      await run(() => supabase.from('dispute_candidates').delete().eq('user_id', user.id));
-      await run(() => supabase.from('disputes').delete().eq('user_id', user.id));
-      await run(() => supabase.from('credit_reports').delete().eq('user_id', user.id));
-      await run(() => supabase.from('audit_access').delete().eq('user_id', user.id));
-      await run(() => supabase.from('consents').delete().eq('user_id', user.id));
-      await run(() => supabase.from('profiles').delete().eq('id', user.id));
+      await run(() =>
+        supabase.storage.from("reports").remove([`users/${user.id}`]),
+      );
+      await run(() =>
+        supabase.storage.from("letters").remove([`users/${user.id}`]),
+      );
+      await run(() =>
+        supabase.from("notifications").delete().eq("user_id", user.id),
+      );
+      await run(() =>
+        supabase.from("dispute_candidates").delete().eq("user_id", user.id),
+      );
+      await run(() =>
+        supabase.from("disputes").delete().eq("user_id", user.id),
+      );
+      await run(() =>
+        supabase.from("credit_reports").delete().eq("user_id", user.id),
+      );
+      await run(() =>
+        supabase.from("audit_access").delete().eq("user_id", user.id),
+      );
+      await run(() =>
+        supabase.from("consents").delete().eq("user_id", user.id),
+      );
+      await run(() => supabase.from("profiles").delete().eq("id", user.id));
       if (user.email) {
         await mailer.send({
           to: user.email,
-          subject: 'Your data has been deleted',
-          html: 'All of your data has been removed from CreditCraft.',
+          subject: "Your data has been deleted",
+          html: "All of your data has been removed from CreditCraft.",
         });
       }
       return {};
     } catch (e) {
       return {
         error: {
-          code: 'SERVER_ERROR',
-          message: e instanceof Error ? e.message : 'Failed to delete data',
+          code: "SERVER_ERROR",
+          message: e instanceof Error ? e.message : "Failed to delete data",
         },
       };
     }
@@ -84,16 +116,47 @@ export default async function SettingsPage() {
     <div>
       <h1>Profile</h1>
       <FormWithToast action={updateProfile}>
-        <label>Name <input name="display_name" defaultValue={profile?.display_name || ''} /></label><br />
-        <label>Address <input name="address_line1" defaultValue={profile?.address_line1 || ''} /></label><br />
-        <label>City <input name="city" defaultValue={profile?.city || ''} /></label><br />
-        <label>State <input name="state" defaultValue={profile?.state || ''} /></label><br />
-        <label>Postal <input name="postal_code" defaultValue={profile?.postal_code || ''} /></label><br />
+        <label>
+          Name{" "}
+          <input
+            name="display_name"
+            defaultValue={profile?.display_name || ""}
+          />
+        </label>
+        <br />
+        <label>
+          Address{" "}
+          <input
+            name="address_line1"
+            defaultValue={profile?.address_line1 || ""}
+          />
+        </label>
+        <br />
+        <label>
+          City <input name="city" defaultValue={profile?.city || ""} />
+        </label>
+        <br />
+        <label>
+          State <input name="state" defaultValue={profile?.state || ""} />
+        </label>
+        <br />
+        <label>
+          Postal{" "}
+          <input name="postal_code" defaultValue={profile?.postal_code || ""} />
+        </label>
+        <br />
         <button type="submit">Save</button>
       </FormWithToast>
-      <p><a href="/api/export-my-data">Export My Data</a></p>
+      <p>
+        <a href="/api/export-my-data">Export My Data</a>
+      </p>
+      <p>
+        <a href="/settings/logs">View Logs</a>
+      </p>
       <FormWithToast action={deleteMyData}>
-        <button type="submit" style={{ marginTop: 20, color: 'red' }}>Delete My Data</button>
+        <button type="submit" style={{ marginTop: 20, color: "red" }}>
+          Delete My Data
+        </button>
       </FormWithToast>
     </div>
   );

--- a/edge-functions/ai-suggest-disputes/index.ts
+++ b/edge-functions/ai-suggest-disputes/index.ts
@@ -2,65 +2,109 @@ import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { z } from "https://deno.land/x/zod@v3.22.2/mod.ts";
 import type { AppError } from "../../lib/utils/errors.ts";
+import { withEdgeLogging } from "../../lib/logs.ts";
 
 const schema = z.object({ reportId: z.string().uuid() });
 
-serve(async (req) => {
-  const supabase = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!);
-  let body: unknown;
-  try {
-    body = await req.json();
-  } catch {
-    const error: AppError = { code: 'INVALID_INPUT', message: 'Invalid JSON' };
-    return new Response(JSON.stringify({ ok: false, error }), { status: 400, headers: { 'Content-Type': 'application/json' } });
-  }
-  const parsed = schema.safeParse(body);
-  if (!parsed.success)
-    return new Response(
-      JSON.stringify({ ok: false, error: { code: 'INVALID_INPUT', message: parsed.error.message } as AppError }),
-      { status: 400, headers: { 'Content-Type': 'application/json' } },
+serve(
+  withEdgeLogging("ai-suggest-disputes", async (req) => {
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
     );
-  const { reportId } = parsed.data;
-  try {
-    const report = await supabase.from('credit_reports').select('user_id').eq('id', reportId).single();
-    if (!report.data) {
-      const error: AppError = { code: 'REPORT_NOT_FOUND', message: 'Report not found' };
-      return new Response(JSON.stringify({ ok: false, error }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      const error: AppError = {
+        code: "INVALID_INPUT",
+        message: "Invalid JSON",
+      };
+      return {
+        response: new Response(JSON.stringify({ ok: false, error }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }),
+      };
     }
-    const suggestions = [
-      {
-        id: crypto.randomUUID(),
-        user_id: report.data.user_id,
-        report_id: reportId,
-        tradeline_id: null,
-        kind: 'late_payment_error',
-        rationale: 'Reported 30 days late but paid on time',
-        confidence: 0.8,
-      },
-      {
-        id: crypto.randomUUID(),
-        user_id: report.data.user_id,
-        report_id: reportId,
-        tradeline_id: null,
-        kind: 'not_mine',
-        rationale: 'Account not recognized',
-        confidence: 0.6,
-      },
-    ];
-    for (const s of suggestions) {
-      await supabase.from('dispute_candidates').insert(s);
+    const parsed = schema.safeParse(body);
+    if (!parsed.success) {
+      return {
+        response: new Response(
+          JSON.stringify({
+            ok: false,
+            error: {
+              code: "INVALID_INPUT",
+              message: parsed.error.message,
+            } as AppError,
+          }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        ),
+      };
     }
-    return new Response(JSON.stringify({ ok: true, suggestions }), {
-      headers: { 'Content-Type': 'application/json' },
-    });
-  } catch (e) {
-    const error: AppError = {
-      code: 'SUGGEST_FAILED',
-      message: e instanceof Error ? e.message : 'Failed to generate suggestions',
-    };
-    return new Response(JSON.stringify({ ok: false, error }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    });
-  }
-});
+    const { reportId } = parsed.data;
+    let userId: string | null = null;
+    try {
+      const report = await supabase
+        .from("credit_reports")
+        .select("user_id")
+        .eq("id", reportId)
+        .single();
+      if (!report.data) {
+        const error: AppError = {
+          code: "REPORT_NOT_FOUND",
+          message: "Report not found",
+        };
+        return {
+          response: new Response(JSON.stringify({ ok: false, error }), {
+            status: 404,
+            headers: { "Content-Type": "application/json" },
+          }),
+        };
+      }
+      userId = report.data.user_id;
+      const suggestions = [
+        {
+          id: crypto.randomUUID(),
+          user_id: report.data.user_id,
+          report_id: reportId,
+          tradeline_id: null,
+          kind: "late_payment_error",
+          rationale: "Reported 30 days late but paid on time",
+          confidence: 0.8,
+        },
+        {
+          id: crypto.randomUUID(),
+          user_id: report.data.user_id,
+          report_id: reportId,
+          tradeline_id: null,
+          kind: "not_mine",
+          rationale: "Account not recognized",
+          confidence: 0.6,
+        },
+      ];
+      for (const s of suggestions) {
+        await supabase.from("dispute_candidates").insert(s);
+      }
+      return {
+        response: new Response(JSON.stringify({ ok: true, suggestions }), {
+          headers: { "Content-Type": "application/json" },
+        }),
+        userId,
+      };
+    } catch (e) {
+      const error: AppError = {
+        code: "SUGGEST_FAILED",
+        message:
+          e instanceof Error ? e.message : "Failed to generate suggestions",
+      };
+      return {
+        response: new Response(JSON.stringify({ ok: false, error }), {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        }),
+        userId,
+      };
+    }
+  }),
+);

--- a/edge-functions/cron-due-reminders/index.ts
+++ b/edge-functions/cron-due-reminders/index.ts
@@ -2,97 +2,127 @@ import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { z } from "https://deno.land/x/zod@v3.22.2/mod.ts";
 import type { AppError } from "../../lib/utils/errors.ts";
+import { withEdgeLogging } from "../../lib/logs.ts";
 
-const CRON_NAME = 'cron_due_reminders';
+const CRON_NAME = "cron_due_reminders";
 const JITTER_MS = 15 * 60 * 1000; // 15 minutes
 
 async function sendMail(to: string, subject: string, html: string) {
-  const apiKey = Deno.env.get('RESEND_API_KEY');
+  const apiKey = Deno.env.get("RESEND_API_KEY");
   if (!apiKey) return;
-  await fetch('https://api.resend.com/emails', {
-    method: 'POST',
+  await fetch("https://api.resend.com/emails", {
+    method: "POST",
     headers: {
-      'Authorization': `Bearer ${apiKey}`,
-      'Content-Type': 'application/json'
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
     },
-    body: JSON.stringify({ from: 'no-reply@creditcraft.local', to, subject, html })
+    body: JSON.stringify({
+      from: "no-reply@creditcraft.local",
+      to,
+      subject,
+      html,
+    }),
   });
 }
 
 const schema = z.object({});
 
-serve(async (req) => {
-  const supabase = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!);
-  try {
-    let body: unknown = {};
+serve(
+  withEdgeLogging("cron-due-reminders", async (req) => {
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+    );
     try {
-      body = await req.json();
-    } catch {}
-    const parsed = schema.safeParse(body);
-    if (!parsed.success) {
-      const error: AppError = { code: 'INVALID_INPUT', message: parsed.error.message };
-      return new Response(JSON.stringify({ ok: false, error }), { status: 400, headers: { 'Content-Type': 'application/json' } });
-    }
-    const now = new Date();
-    const { data: lastRuns } = await supabase
-      .from('last_cron_run')
-      .select('ran_at')
-      .eq('name', CRON_NAME)
-      .limit(1);
-    const lastRun = lastRuns && lastRuns.length > 0 && lastRuns[0].ran_at
-      ? new Date(lastRuns[0].ran_at)
-      : new Date(0);
-    const windowStart = new Date(lastRun.getTime() - JITTER_MS);
-    const windowEnd = new Date(now.getTime() + 1000 * 60 * 60 * 48 + JITTER_MS);
-
-    const { data, error: disputeError } = await supabase
-      .from('disputes')
-      .select('id,user_id')
-      .eq('status', 'sent')
-      .gte('due_at', windowStart.toISOString())
-      .lte('due_at', windowEnd.toISOString());
-    if (disputeError) throw disputeError;
-
-    let count = 0;
-    for (const d of data || []) {
-      const notifyDate = now.toISOString().slice(0, 10);
-      const { error: insertError } = await supabase
-        .from('notifications')
-        .insert({
-          id: crypto.randomUUID(),
-          user_id: d.user_id,
-          dispute_id: d.id,
-          type: 'dispute_due',
-          message: `Dispute ${d.id} due soon`,
-          notify_date: notifyDate,
-        });
-      if (insertError) {
-        if (insertError.code === '23505') {
-          console.log(`Duplicate notification for dispute ${d.id}, skipping`);
-          continue;
-        }
-        throw insertError;
+      let body: unknown = {};
+      try {
+        body = await req.json();
+      } catch {}
+      const parsed = schema.safeParse(body);
+      if (!parsed.success) {
+        const error: AppError = {
+          code: "INVALID_INPUT",
+          message: parsed.error.message,
+        };
+        return {
+          response: new Response(JSON.stringify({ ok: false, error }), {
+            status: 400,
+            headers: { "Content-Type": "application/json" },
+          }),
+        };
       }
-      await sendMail('user@example.com', 'Dispute Due', `Dispute ${d.id} due soon`);
-      count++;
+      const now = new Date();
+      const { data: lastRuns } = await supabase
+        .from("last_cron_run")
+        .select("ran_at")
+        .eq("name", CRON_NAME)
+        .limit(1);
+      const lastRun =
+        lastRuns && lastRuns.length > 0 && lastRuns[0].ran_at
+          ? new Date(lastRuns[0].ran_at)
+          : new Date(0);
+      const windowStart = new Date(lastRun.getTime() - JITTER_MS);
+      const windowEnd = new Date(
+        now.getTime() + 1000 * 60 * 60 * 48 + JITTER_MS,
+      );
+
+      const { data, error: disputeError } = await supabase
+        .from("disputes")
+        .select("id,user_id")
+        .eq("status", "sent")
+        .gte("due_at", windowStart.toISOString())
+        .lte("due_at", windowEnd.toISOString());
+      if (disputeError) throw disputeError;
+
+      let count = 0;
+      for (const d of data || []) {
+        const notifyDate = now.toISOString().slice(0, 10);
+        const { error: insertError } = await supabase
+          .from("notifications")
+          .insert({
+            id: crypto.randomUUID(),
+            user_id: d.user_id,
+            dispute_id: d.id,
+            type: "dispute_due",
+            message: `Dispute ${d.id} due soon`,
+            notify_date: notifyDate,
+          });
+        if (insertError) {
+          if (insertError.code === "23505") {
+            console.log(`Duplicate notification for dispute ${d.id}, skipping`);
+            continue;
+          }
+          throw insertError;
+        }
+        await sendMail(
+          "user@example.com",
+          "Dispute Due",
+          `Dispute ${d.id} due soon`,
+        );
+        count++;
+      }
+
+      await supabase
+        .from("last_cron_run")
+        .upsert({ name: CRON_NAME, ran_at: now.toISOString() });
+
+      console.log(`cron-due-reminders completed, processed ${count}`);
+      return {
+        response: new Response(JSON.stringify({ ok: true, count }), {
+          headers: { "Content-Type": "application/json" },
+        }),
+      };
+    } catch (e) {
+      const error: AppError = {
+        code: "REMINDERS_FAILED",
+        message: e instanceof Error ? e.message : "Failed to send reminders",
+      };
+      return {
+        response: new Response(JSON.stringify({ ok: false, error }), {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        }),
+      };
     }
-
-    await supabase
-      .from('last_cron_run')
-      .upsert({ name: CRON_NAME, ran_at: now.toISOString() });
-
-    console.log(`cron-due-reminders completed, processed ${count}`);
-    return new Response(JSON.stringify({ ok: true, count }), {
-      headers: { 'Content-Type': 'application/json' },
-    });
-  } catch (e) {
-    const error: AppError = {
-      code: 'REMINDERS_FAILED',
-      message: e instanceof Error ? e.message : 'Failed to send reminders',
-    };
-    return new Response(JSON.stringify({ ok: false, error }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    });
-  }
-});
+  }),
+);

--- a/edge-functions/gen-dispute-letter/index.ts
+++ b/edge-functions/gen-dispute-letter/index.ts
@@ -2,56 +2,122 @@ import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { z } from "https://deno.land/x/zod@v3.22.2/mod.ts";
 import type { AppError } from "../../lib/utils/errors.ts";
+import { withEdgeLogging } from "../../lib/logs.ts";
 
 const schema = z.object({ disputeId: z.string().uuid() });
 
-serve(async (req) => {
-  const supabase = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!);
-  let body: unknown;
-  try {
-    body = await req.json();
-  } catch {
-    const error: AppError = { code: 'INVALID_INPUT', message: 'Invalid JSON' };
-    return new Response(JSON.stringify({ ok: false, error }), { status: 400, headers: { 'Content-Type': 'application/json' } });
-  }
-  const parsed = schema.safeParse(body);
-  if (!parsed.success)
-    return new Response(
-      JSON.stringify({ ok: false, error: { code: 'INVALID_INPUT', message: parsed.error.message } as AppError }),
-      { status: 400, headers: { 'Content-Type': 'application/json' } },
+serve(
+  withEdgeLogging("gen-dispute-letter", async (req) => {
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
     );
-  const { disputeId } = parsed.data;
-  try {
-    const dispute = await supabase.from('disputes').select('*').eq('id', disputeId).single();
-    if (!dispute.data) {
-      const error: AppError = { code: 'DISPUTE_NOT_FOUND', message: 'Dispute not found' };
-      return new Response(JSON.stringify({ ok: false, error }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      const error: AppError = {
+        code: "INVALID_INPUT",
+        message: "Invalid JSON",
+      };
+      return {
+        response: new Response(JSON.stringify({ ok: false, error }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }),
+      };
     }
-    const user = await supabase.from('profiles').select('*').eq('id', dispute.data.user_id).single();
-    const template = await (await fetch(new URL(`../../templates/${dispute.data.bureau}.txt`, import.meta.url))).text();
-    let content = template
-      .replace('{{CONSUMER_NAME}}', user.data!.display_name || '')
-      .replace('{{ADDRESS}}', `${user.data!.address_line1 || ''} ${user.data!.address_line2 || ''}`)
-      .replace(
-        '{{CITY_STATE_ZIP}}',
-        `${user.data!.city || ''}, ${user.data!.state || ''} ${user.data!.postal_code || ''}`,
-      )
-      .replace('{{REPORT_PERIOD}}', '');
-    // simple items join
-    content = content.replace('{{ITEMS_TABLE}}', JSON.stringify(dispute.data.items));
-    const pdfBytes = new TextEncoder().encode(content);
-    const path = `users/${user.data!.id}/disputes/${disputeId}.pdf`;
-    await supabase.storage.from('letters').upload(path, pdfBytes, { contentType: 'application/pdf' });
-    await supabase.from('disputes').update({ letter_pdf_path: path }).eq('id', disputeId);
-    return new Response(JSON.stringify({ ok: true, path }), { headers: { 'Content-Type': 'application/json' } });
-  } catch (e) {
-    const error: AppError = {
-      code: 'GEN_LETTER_FAILED',
-      message: e instanceof Error ? e.message : 'Failed to generate letter',
-    };
-    return new Response(JSON.stringify({ ok: false, error }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    });
-  }
-});
+    const parsed = schema.safeParse(body);
+    if (!parsed.success)
+      return {
+        response: new Response(
+          JSON.stringify({
+            ok: false,
+            error: {
+              code: "INVALID_INPUT",
+              message: parsed.error.message,
+            } as AppError,
+          }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        ),
+      };
+    const { disputeId } = parsed.data;
+    let userId: string | null = null;
+    try {
+      const dispute = await supabase
+        .from("disputes")
+        .select("*")
+        .eq("id", disputeId)
+        .single();
+      if (!dispute.data) {
+        const error: AppError = {
+          code: "DISPUTE_NOT_FOUND",
+          message: "Dispute not found",
+        };
+        return {
+          response: new Response(JSON.stringify({ ok: false, error }), {
+            status: 404,
+            headers: { "Content-Type": "application/json" },
+          }),
+        };
+      }
+      userId = dispute.data.user_id;
+      const user = await supabase
+        .from("profiles")
+        .select("*")
+        .eq("id", dispute.data.user_id)
+        .single();
+      const template = await (
+        await fetch(
+          new URL(
+            `../../templates/${dispute.data.bureau}.txt`,
+            import.meta.url,
+          ),
+        )
+      ).text();
+      let content = template
+        .replace("{{CONSUMER_NAME}}", user.data!.display_name || "")
+        .replace(
+          "{{ADDRESS}}",
+          `${user.data!.address_line1 || ""} ${user.data!.address_line2 || ""}`,
+        )
+        .replace(
+          "{{CITY_STATE_ZIP}}",
+          `${user.data!.city || ""}, ${user.data!.state || ""} ${user.data!.postal_code || ""}`,
+        )
+        .replace("{{REPORT_PERIOD}}", "");
+      // simple items join
+      content = content.replace(
+        "{{ITEMS_TABLE}}",
+        JSON.stringify(dispute.data.items),
+      );
+      const pdfBytes = new TextEncoder().encode(content);
+      const path = `users/${user.data!.id}/disputes/${disputeId}.pdf`;
+      await supabase.storage
+        .from("letters")
+        .upload(path, pdfBytes, { contentType: "application/pdf" });
+      await supabase
+        .from("disputes")
+        .update({ letter_pdf_path: path })
+        .eq("id", disputeId);
+      return {
+        response: new Response(JSON.stringify({ ok: true, path }), {
+          headers: { "Content-Type": "application/json" },
+        }),
+        userId,
+      };
+    } catch (e) {
+      const error: AppError = {
+        code: "GEN_LETTER_FAILED",
+        message: e instanceof Error ? e.message : "Failed to generate letter",
+      };
+      return {
+        response: new Response(JSON.stringify({ ok: false, error }), {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        }),
+        userId,
+      };
+    }
+  }),
+);

--- a/edge-functions/parse-report/index.ts
+++ b/edge-functions/parse-report/index.ts
@@ -2,6 +2,7 @@ import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { z } from "https://deno.land/x/zod@v3.22.2/mod.ts";
 import type { AppError } from "../../lib/utils/errors.ts";
+import { withEdgeLogging } from "../../lib/logs.ts";
 
 const schema = z.object({
   reportId: z.string().uuid(),
@@ -9,90 +10,105 @@ const schema = z.object({
   storagePath: z.string().min(1),
 });
 
-serve(async (req) => {
-  const supabase = createClient(
-    Deno.env.get('SUPABASE_URL')!,
-    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
-  );
-  let body: unknown;
-  try {
-    body = await req.json();
-  } catch {
-    const error: AppError = { code: 'INVALID_INPUT', message: 'Invalid JSON' };
-    return new Response(JSON.stringify({ ok: false, error }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    });
-  }
-  const parsed = schema.safeParse(body);
-  if (!parsed.success) {
-    const error: AppError = {
-      code: 'INVALID_INPUT',
-      message: parsed.error.message,
-    };
-    return new Response(JSON.stringify({ ok: false, error }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    });
-  }
-  // mock parser
-  const { reportId, userId } = parsed.data;
-  try {
-    const tradelines = [
-      {
-        id: crypto.randomUUID(),
-        report_id: reportId,
-        creditor: 'Mock Bank',
-        acct_mask: '1234',
-        type: 'credit_card',
-        balance: 50000,
-        credit_limit: 100000,
-        status: 'open',
-        opened_date: '2020-01-01',
-        last_reported: '2024-01-01',
-        late_30: 0,
-        late_60: 0,
-        late_90: 0,
-      },
-      {
-        id: crypto.randomUUID(),
-        report_id: reportId,
-        creditor: 'Mock Auto',
-        acct_mask: '9876',
-        type: 'auto',
-        balance: 2000000,
-        credit_limit: null,
-        status: 'open',
-        opened_date: '2019-06-01',
-        last_reported: '2024-01-01',
-        late_30: 1,
-        late_60: 0,
-        late_90: 0,
-      },
-    ];
-    await supabase
-      .from('credit_reports')
-      .update({
-        status: 'parsed',
-        parsed_at: new Date().toISOString(),
-        summary: { tradelines: tradelines.length },
-      })
-      .eq('id', reportId)
-      .eq('user_id', userId);
-    for (const t of tradelines) {
-      await supabase.from('tradelines').insert(t);
+serve(
+  withEdgeLogging("parse-report", async (req) => {
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+    );
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      const error: AppError = {
+        code: "INVALID_INPUT",
+        message: "Invalid JSON",
+      };
+      return {
+        response: new Response(JSON.stringify({ ok: false, error }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }),
+      };
     }
-    return new Response(JSON.stringify({ ok: true, tradelines }), {
-      headers: { 'Content-Type': 'application/json' },
-    });
-  } catch (e) {
-    const error: AppError = {
-      code: 'PARSE_FAILED',
-      message: e instanceof Error ? e.message : 'Failed to parse report',
-    };
-    return new Response(JSON.stringify({ ok: false, error }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    });
-  }
-});
+    const parsed = schema.safeParse(body);
+    if (!parsed.success) {
+      const error: AppError = {
+        code: "INVALID_INPUT",
+        message: parsed.error.message,
+      };
+      return {
+        response: new Response(JSON.stringify({ ok: false, error }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }),
+      };
+    }
+    // mock parser
+    const { reportId, userId } = parsed.data;
+    try {
+      const tradelines = [
+        {
+          id: crypto.randomUUID(),
+          report_id: reportId,
+          creditor: "Mock Bank",
+          acct_mask: "1234",
+          type: "credit_card",
+          balance: 50000,
+          credit_limit: 100000,
+          status: "open",
+          opened_date: "2020-01-01",
+          last_reported: "2024-01-01",
+          late_30: 0,
+          late_60: 0,
+          late_90: 0,
+        },
+        {
+          id: crypto.randomUUID(),
+          report_id: reportId,
+          creditor: "Mock Auto",
+          acct_mask: "9876",
+          type: "auto",
+          balance: 2000000,
+          credit_limit: null,
+          status: "open",
+          opened_date: "2019-06-01",
+          last_reported: "2024-01-01",
+          late_30: 1,
+          late_60: 0,
+          late_90: 0,
+        },
+      ];
+      await supabase
+        .from("credit_reports")
+        .update({
+          status: "parsed",
+          parsed_at: new Date().toISOString(),
+          summary: { tradelines: tradelines.length },
+        })
+        .eq("id", reportId)
+        .eq("user_id", userId);
+      for (const t of tradelines) {
+        await supabase.from("tradelines").insert(t);
+      }
+      return {
+        response: new Response(JSON.stringify({ ok: true, tradelines }), {
+          headers: { "Content-Type": "application/json" },
+        }),
+        userId,
+      };
+    } catch (e) {
+      const error: AppError = {
+        code: "PARSE_FAILED",
+        message: e instanceof Error ? e.message : "Failed to parse report",
+      };
+      return {
+        response: new Response(JSON.stringify({ ok: false, error }), {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        }),
+        userId,
+      };
+    }
+  }),
+);

--- a/lib/logs.ts
+++ b/lib/logs.ts
@@ -1,0 +1,62 @@
+export interface LogEntry {
+  requestId: string;
+  userId: string | null;
+  functionName: string;
+  durationMs: number;
+  result: "ok" | "error";
+}
+
+const logStore: LogEntry[] = [];
+
+export function log(entry: LogEntry) {
+  logStore.push(entry);
+  console.log(JSON.stringify(entry));
+}
+
+export function getLogsForUser(userId: string): LogEntry[] {
+  return logStore.filter((l) => l.userId === userId);
+}
+
+export function withEdgeLogging(
+  functionName: string,
+  handler: (
+    req: Request,
+  ) => Promise<{ response: Response; userId?: string | null }>,
+) {
+  return async (req: Request): Promise<Response> => {
+    const requestId = req.headers.get("x-request-id") ?? crypto.randomUUID();
+    const start = Date.now();
+    try {
+      const { response, userId } = await handler(req);
+      const durationMs = Date.now() - start;
+      log({
+        requestId,
+        userId: userId ?? null,
+        functionName,
+        durationMs,
+        result: "ok",
+      });
+      return response;
+    } catch (e) {
+      const durationMs = Date.now() - start;
+      log({
+        requestId,
+        userId: null,
+        functionName,
+        durationMs,
+        result: "error",
+      });
+      console.error(e);
+      return new Response(
+        JSON.stringify({
+          ok: false,
+          error: {
+            code: "SERVER_ERROR",
+            message: e instanceof Error ? e.message : "Server error",
+          },
+        }),
+        { status: 500, headers: { "Content-Type": "application/json" } },
+      );
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add structured logging utility with edge function wrapper
- instrument edge functions to log execution details
- expose log preview page under settings for users

## Testing
- `npm test` *(fails: Failed to load url @react-pdf/renderer ...)*
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module '@supabase/auth-ui-shared', ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b20a68a4832f993bd65741a71f81