### PR TITLE
Optimize performance and add pagination

### DIFF
--- a/app/(dashboard)/disputes/[id]/page.tsx
+++ b/app/(dashboard)/disputes/[id]/page.tsx
@@ -43,6 +43,9 @@ export default async function DisputeDetail({ params }: { params: { id: string }
   async function genLetter(): Promise<{ error?: AppError }> {
     'use server';
     try {
+      if (dispute?.letter_pdf_path) {
+        return {};
+      }
       const { data, error } = await supabase.functions.invoke('gen-dispute-letter', {
         body: { disputeId: params.id },
       });
@@ -92,6 +95,14 @@ export default async function DisputeDetail({ params }: { params: { id: string }
   async function markMailed(): Promise<{ error?: AppError }> {
     'use server';
     try {
+      const { data: existing } = await supabase
+        .from('disputes')
+        .select('status')
+        .eq('id', params.id)
+        .single();
+      if (existing?.status === 'sent') {
+        return {};
+      }
       const due = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
       await supabase
         .from('disputes')

--- a/app/(dashboard)/disputes/page.tsx
+++ b/app/(dashboard)/disputes/page.tsx
@@ -2,16 +2,26 @@ import Link from 'next/link';
 import { createServerClient } from '../../../lib/supabase/server';
 import Card from '../../../components/Card';
 import EmptyState from '../../../components/EmptyState';
-import styles from './page.module.css';
+import VirtualList from '../../../components/VirtualList';
 
-export default async function DisputesPage() {
+const PAGE_SIZE = 10;
+
+async function getDisputes(page: number) {
   const supabase = createServerClient();
-  const { data } = await supabase
+  const { data, count } = await supabase
     .from('disputes')
-    .select('*')
-    .order('created_at', { ascending: false });
+    .select('*', { count: 'exact' })
+    .order('created_at', { ascending: false })
+    .range((page - 1) * PAGE_SIZE, page * PAGE_SIZE - 1);
+  return { disputes: data || [], count: count || 0 };
+}
 
-  if (!data || data.length === 0) {
+export default async function DisputesPage({ searchParams }: { searchParams: { page?: string } }) {
+  const page = parseInt(searchParams.page || '1', 10);
+  const { disputes, count } = await getDisputes(page);
+  const totalPages = Math.max(1, Math.ceil(count / PAGE_SIZE));
+
+  if (!disputes || disputes.length === 0) {
     return (
       <div>
         <h1>Disputes</h1>
@@ -23,15 +33,26 @@ export default async function DisputesPage() {
   return (
     <div>
       <h1>Disputes</h1>
-      <ul className={styles.list}>
-        {data.map((d) => (
-          <li key={d.id}>
+      <VirtualList
+        items={disputes}
+        itemHeight={80}
+        height={400}
+        renderItem={(d) => (
+          <div key={d.id} style={{ height: 80, marginBottom: 'var(--space-4)' }}>
             <Card>
               <Link href={`/disputes/${d.id}`}>{d.status}</Link>
             </Card>
-          </li>
-        ))}
-      </ul>
+          </div>
+        )}
+      />
+      <div>
+        {page > 1 && <Link href={`/disputes?page=${page - 1}`}>Previous</Link>}
+        {page < totalPages && (
+          <Link href={`/disputes?page=${page + 1}`} style={{ marginLeft: 8 }}>
+            Next
+          </Link>
+        )}
+      </div>
     </div>
   );
 }

--- a/app/(dashboard)/reports/[id]/page.tsx
+++ b/app/(dashboard)/reports/[id]/page.tsx
@@ -17,6 +17,14 @@ export default async function ReportDetail({ params }: { params: { id: string } 
   async function findCandidates(): Promise<{ error?: AppError }> {
     'use server';
     try {
+      const { data: existing } = await supabase
+        .from('dispute_candidates')
+        .select('id')
+        .eq('report_id', params.id)
+        .limit(1);
+      if (existing && existing.length > 0) {
+        return {};
+      }
       const suggestions = await aiProvider.suggestDisputes(params.id);
       const rows = suggestions.map((s) => ({
         ...s,

--- a/app/(dashboard)/reports/page.tsx
+++ b/app/(dashboard)/reports/page.tsx
@@ -1,24 +1,46 @@
 import Link from 'next/link';
 import Upload from './Upload';
 import { createServerClient } from '../../../lib/supabase/server';
+import VirtualList from '../../../components/VirtualList';
 
-async function getReports() {
+const PAGE_SIZE = 10;
+
+async function getReports(page: number) {
   const supabase = createServerClient();
-  const { data } = await supabase.from('credit_reports').select('*').order('created_at', { ascending: false });
-  return data || [];
+  const { data, count } = await supabase
+    .from('credit_reports')
+    .select('*', { count: 'exact' })
+    .order('created_at', { ascending: false })
+    .range((page - 1) * PAGE_SIZE, page * PAGE_SIZE - 1);
+  return { reports: data || [], count: count || 0 };
 }
 
-export default async function ReportsPage() {
-  const reports = await getReports();
+export default async function ReportsPage({ searchParams }: { searchParams: { page?: string } }) {
+  const page = parseInt(searchParams.page || '1', 10);
+  const { reports, count } = await getReports(page);
+  const totalPages = Math.max(1, Math.ceil(count / PAGE_SIZE));
   return (
     <div>
       <h1>Reports</h1>
       <Upload />
-      <ul>
-        {reports.map(r => (
-          <li key={r.id}><Link href={`/reports/${r.id}`}>{r.bureau || 'Unknown'} - {r.status}</Link></li>
-        ))}
-      </ul>
+      <VirtualList
+        items={reports}
+        itemHeight={40}
+        height={400}
+        renderItem={(r) => (
+          <div key={r.id} style={{ height: 40 }}>
+            <Link href={`/reports/${r.id}`}>{r.bureau || 'Unknown'} - {r.status}</Link>
+          </div>
+        )}
+      />
+      <div>
+        {page > 1 && <Link href={`/reports?page=${page - 1}`}>Previous</Link>}
+        {page < totalPages && (
+          <Link href={`/reports?page=${page + 1}`} style={{ marginLeft: 8 }}>
+            Next
+          </Link>
+        )}
+      </div>
     </div>
   );
 }

--- a/components/VirtualList.tsx
+++ b/components/VirtualList.tsx
@@ -1,0 +1,27 @@
+'use client';
+import { useState } from 'react';
+
+interface Props<T> {
+  items: T[];
+  itemHeight: number;
+  height: number;
+  renderItem: (item: T, index: number) => React.ReactNode;
+}
+
+export default function VirtualList<T>({ items, itemHeight, height, renderItem }: Props<T>) {
+  const [scrollTop, setScrollTop] = useState(0);
+  const totalHeight = items.length * itemHeight;
+  const start = Math.floor(scrollTop / itemHeight);
+  const end = Math.min(items.length, Math.ceil((scrollTop + height) / itemHeight));
+  const visible = items.slice(start, end);
+  const offset = start * itemHeight;
+  return (
+    <div style={{ overflowY: 'auto', height }} onScroll={e => setScrollTop(e.currentTarget.scrollTop)}>
+      <div style={{ height: totalHeight, position: 'relative' }}>
+        <div style={{ position: 'absolute', top: offset, left: 0, right: 0 }}>
+          {visible.map((item, i) => renderItem(item, start + i))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/edge-functions/ai-suggest-disputes/index.ts
+++ b/edge-functions/ai-suggest-disputes/index.ts
@@ -63,6 +63,19 @@ serve(
         };
       }
       userId = report.data.user_id;
+      const { data: existing } = await supabase
+        .from("dispute_candidates")
+        .select("*")
+        .eq("report_id", reportId);
+      if (existing && existing.length > 0) {
+        return {
+          response: new Response(
+            JSON.stringify({ ok: true, suggestions: existing }),
+            { headers: { "Content-Type": "application/json" } },
+          ),
+          userId,
+        };
+      }
       const suggestions = [
         {
           id: crypto.randomUUID(),

--- a/edge-functions/gen-dispute-letter/index.ts
+++ b/edge-functions/gen-dispute-letter/index.ts
@@ -62,6 +62,15 @@ serve(
         };
       }
       userId = dispute.data.user_id;
+      if (dispute.data.letter_pdf_path) {
+        return {
+          response: new Response(
+            JSON.stringify({ ok: true, path: dispute.data.letter_pdf_path }),
+            { headers: { "Content-Type": "application/json" } },
+          ),
+          userId,
+        };
+      }
       const profile = await supabase
         .from("profiles")
         .select("*")

--- a/edge-functions/parse-report/index.ts
+++ b/edge-functions/parse-report/index.ts
@@ -47,6 +47,21 @@ serve(
     // mock parser
     const { reportId, userId } = parsed.data;
     try {
+      const { data: existing } = await supabase
+        .from("credit_reports")
+        .select("status")
+        .eq("id", reportId)
+        .eq("user_id", userId)
+        .single();
+      if (existing?.status === "parsed") {
+        return {
+          response: new Response(
+            JSON.stringify({ ok: true, parsed: true }),
+            { headers: { "Content-Type": "application/json" } },
+          ),
+          userId,
+        };
+      }
       const tradelines = [
         {
           id: crypto.randomUUID(),

--- a/lib/pdf/index.tsx
+++ b/lib/pdf/index.tsx
@@ -8,9 +8,18 @@ export type Bureau = 'equifax' | 'experian' | 'transunion';
 
 export interface RenderData extends Omit<LetterData, 'bureau' | 'qrDataUrl'> {}
 
+const cache = new Map<string, Buffer>();
+
 export async function renderLetter(bureau: Bureau, data: RenderData): Promise<Buffer> {
+  const key = JSON.stringify({ bureau, data });
+  const cached = cache.get(key);
+  if (cached) {
+    return cached;
+  }
   const Template = (templates as Record<string, any>)[bureau];
   const qrDataUrl = await QRCode.toDataURL(data.detailUrl);
   const element = <Template {...data} qrDataUrl={qrDataUrl} />;
-  return await renderToBuffer(element);
+  const buffer = await renderToBuffer(element);
+  cache.set(key, buffer);
+  return buffer;
 }

--- a/sql/migration.sql
+++ b/sql/migration.sql
@@ -106,6 +106,10 @@ create index if not exists notifications_user_idx on notifications(user_id);
 create unique index if not exists notifications_dispute_type_date_key on notifications(dispute_id, type, notify_date) where dispute_id is not null and type is not null;
 create index if not exists dispute_candidates_report_idx on dispute_candidates(report_id);
 create index if not exists tradelines_report_idx on tradelines(report_id);
+create index if not exists credit_reports_created_at_idx on credit_reports(created_at);
+create index if not exists disputes_created_at_idx on disputes(created_at);
+create index if not exists disputes_status_idx on disputes(status);
+create index if not exists notifications_read_idx on notifications(read);
 
 -- RLS
 alter table profiles enable row level security;


### PR DESCRIPTION
## Summary
- add missing database indexes
- make server actions and edge functions idempotent
- cache rendered letter templates
- paginate and virtualize report and dispute lists

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run typecheck` *(fails: missing type definitions and modules)*
- `npm run build` *(fails: module not found errors)*
- `npx --yes lighthouse https://example.com --quiet --chrome-flags="--headless" --only-categories=performance` *(fails: ChromePathNotSetError)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ccddf254832f8099eefa953de96f