### PR TITLE
Add cross-platform setup scripts for beginners

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,20 @@
 
 AI-assisted credit repair & score coaching tool built with Next.js 14 and Supabase.
 
-## 10-minute setup
-1. Create a new Supabase project and enable Email and Google auth providers.
-2. Create storage buckets: `reports` and `letters`.
-3. Copy `.env.local.example` to `.env.local` and fill in values including `SUPABASE_DB_URL`. Optionally set `SENTRY_DSN`, `CRON_ALERT_WEBHOOK`, and `ADMIN_EMAILS` for monitoring features.
-4. Install dependencies: `npm install`.
-5. Prep a fresh demo database with sample data:
-   ```bash
-   npm run db:reseed
-   ```
-6. Start the dev server:
-   ```bash
-   npm run dev
-   ```
-7. Deploy edge functions in `edge-functions` and set a daily cron for `cron-due-reminders`.
+## Quick start
+
+```bash
+git clone <repo-url>
+cd <repo>
+./setup.sh   # or run setup.ps1 on Windows
+```
+
+The script installs Node, Git, Docker, and the Supabase CLI if needed, starts all services, and opens the app at http://localhost:3000 automatically.
+
+### Troubleshooting
+- If it says Docker not running, open Docker Desktop first.
+- Allow any install prompts or password requests so tools can be installed.
+- If the browser doesn't open, visit http://localhost:3000 manually.
 
 ## Features
 - Upload credit reports, parse to tradelines.

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,0 +1,56 @@
+Param()
+
+Set-Location -Path (Split-Path $MyInvocation.MyCommand.Definition)
+
+function Ensure-Tool {
+  param(
+    [string]$Command,
+    [string]$InstallCommand
+  )
+  if (-not (Get-Command $Command -ErrorAction SilentlyContinue)) {
+    Write-Host "Installing $Command..."
+    Invoke-Expression $InstallCommand
+  }
+}
+
+Ensure-Tool git "winget install -e --id Git.Git"
+Ensure-Tool node "winget install -e --id OpenJS.NodeJS.LTS"
+Ensure-Tool docker "winget install -e --id Docker.DockerDesktop"
+Ensure-Tool supabase "winget install -e --id Supabase.Supabase"
+
+try {
+  docker info | Out-Null
+} catch {
+  Write-Host "Docker does not appear to be running. Open Docker Desktop and run this script again." -ForegroundColor Yellow
+  exit 1
+}
+
+supabase start
+
+supabase storage create-bucket reports | Out-Null
+supabase storage create-bucket letters | Out-Null
+
+$status = supabase status
+$apiUrl = ($status | Select-String 'API URL').Line -replace 'API URL:\s*', ''
+$dbUrl = ($status | Select-String 'DB URL').Line -replace 'DB URL:\s*', ''
+$anonKey = ($status | Select-String 'anon key').Line -replace 'anon key:\s*', ''
+$serviceKey = ($status | Select-String 'service_role key').Line -replace 'service_role key:\s*', ''
+
+@"""
+NEXT_PUBLIC_SUPABASE_URL=$apiUrl
+NEXT_PUBLIC_SUPABASE_ANON_KEY=$anonKey
+SUPABASE_SERVICE_ROLE_KEY=$serviceKey
+"""@ | Set-Content -Encoding UTF8 .env.local
+
+$env:SUPABASE_DB_URL = $dbUrl
+npm run db:apply
+npm run db:seed
+
+$functions = Start-Process supabase -ArgumentList "functions serve --env-file .env.local" -PassThru
+
+npm install
+$dev = Start-Process npm -ArgumentList "run","dev" -PassThru
+Start-Sleep -Seconds 5
+Start-Process "http://localhost:3000"
+Wait-Process $dev.Id
+Stop-Process $functions.Id

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -e
+
+cd "$(dirname "$0")"
+
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+install_git() {
+  echo "Installing Git..."
+  if command_exists brew; then
+    brew install git
+  elif command_exists apt-get; then
+    sudo apt-get update && sudo apt-get install -y git
+  else
+    echo "Please install Git manually from https://git-scm.com/downloads" && exit 1
+  fi
+}
+
+install_node() {
+  echo "Installing Node.js..."
+  if command_exists brew; then
+    brew install node
+  elif command_exists apt-get; then
+    curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+    sudo apt-get install -y nodejs
+  else
+    echo "Please install Node.js from https://nodejs.org/" && exit 1
+  fi
+}
+
+install_docker() {
+  echo "Installing Docker..."
+  if command_exists brew; then
+    brew install --cask docker
+    echo "Docker Desktop installed. Please start it if it isn't running."
+  elif command_exists apt-get; then
+    sudo apt-get update && sudo apt-get install -y docker.io
+    sudo systemctl start docker || true
+  else
+    echo "Please install Docker from https://docs.docker.com/get-docker/" && exit 1
+  fi
+}
+
+install_supabase() {
+  echo "Installing Supabase CLI..."
+  if command_exists brew; then
+    brew install supabase/tap/supabase
+  else
+    curl -sL https://supabase.com/cli/install | sh
+    export PATH="/root/.supabase/bin:$PATH"
+  fi
+}
+
+for dep in git node docker supabase; do
+  if ! command_exists $dep; then
+    install_$dep
+  fi
+ done
+
+if ! docker info >/dev/null 2>&1; then
+  echo "Docker does not appear to be running. If you're on Mac or Windows, open Docker Desktop and try again."
+  exit 1
+fi
+
+supabase start
+
+supabase storage create-bucket reports || true
+supabase storage create-bucket letters || true
+
+STATUS=$(supabase status)
+API_URL=$(echo "$STATUS" | grep 'API URL' | awk '{print $3}')
+ANON_KEY=$(echo "$STATUS" | grep 'anon key' | awk '{print $3}')
+SERVICE_KEY=$(echo "$STATUS" | grep 'service_role key' | awk '{print $3}')
+DB_URL=$(echo "$STATUS" | grep 'DB URL' | awk '{print $3}')
+
+cat > .env.local <<ENV
+NEXT_PUBLIC_SUPABASE_URL=$API_URL
+NEXT_PUBLIC_SUPABASE_ANON_KEY=$ANON_KEY
+SUPABASE_SERVICE_ROLE_KEY=$SERVICE_KEY
+ENV
+
+export SUPABASE_DB_URL=$DB_URL
+
+npm run db:apply
+npm run db:seed
+
+supabase functions serve --env-file .env.local >/dev/null 2>&1 &
+FUNC_PID=$!
+
+npm install
+npm run dev &
+DEV_PID=$!
+
+sleep 5
+if command_exists xdg-open; then
+  xdg-open http://localhost:3000 >/dev/null 2>&1 || true
+elif command_exists open; then
+  open http://localhost:3000 >/dev/null 2>&1 || true
+fi
+
+wait $DEV_PID
+kill $FUNC_PID


### PR DESCRIPTION
## Summary
- add `setup.sh` and `setup.ps1` scripts to install tools, start Supabase, seed the DB, and launch the dev server
- update README with one-line quick start and troubleshooting notes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5b9b8f5fc832f81b1437ff29102b3